### PR TITLE
fix: Updated upgrade job schedule

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,8 +2,8 @@ name: Upgrade Requirements
 
 on:
   schedule:
-    # will start the job at 05:30 UTC every Monday
-    - cron: "30 5 * * 1"
+    # will start the job at 00:45 UTC every Monday
+    - cron: "45 0 * * 1"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Updated the upgrade-python-requirements job schedule as we need to run the jobs until 5:00 UTC