### PR TITLE
build(fix): no need to run on Python 3.5 anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         os:
           - ubuntu-20.04
         python-version:
-          - 3.5
           - 3.8
 
     steps:


### PR DESCRIPTION
This prevented the "advertise constraints in setup.py" pull request #37
from working, because it uses f-strings, new in Python 3.6.