### PR TITLE
chore: bump requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,4 @@
 -c constraints.txt
 
 six
-web-fragments
 XBlock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,36 +6,42 @@
 #
 appdirs==1.4.4
     # via fs
+dnspython==2.8.0
+    # via pymongo
+edx-opaque-keys==4.0.0
+    # via xblock
 fs==2.4.16
     # via xblock
-lxml==6.0.2
+lxml==6.1.1
     # via xblock
-mako==1.3.10
+mako==1.3.12
     # via xblock
 markupsafe==3.0.3
     # via
     #   mako
     #   xblock
+pymongo==4.17.0
+    # via edx-opaque-keys
 python-dateutil==2.9.0.post0
     # via xblock
-pytz==2026.1.post1
+pytz==2026.2
     # via xblock
 pyyaml==6.0.3
     # via xblock
-simplejson==3.20.2
+simplejson==4.1.1
     # via xblock
 six==1.17.0
     # via
     #   -r requirements/base.in
     #   fs
     #   python-dateutil
-web-fragments==3.1.0
-    # via
-    #   -r requirements/base.in
-    #   xblock
-webob==1.8.9
+stevedore==5.8.0
+    # via edx-opaque-keys
+typing-extensions==4.15.0
+    # via edx-opaque-keys
+webob==1.8.10
     # via xblock
-xblock==5.3.0
+xblock==6.2.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-packaging==26.0
+packaging==26.2
     # via wheel
-wheel==0.46.3
+wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1.2
     # via -r requirements/pip.in
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-build==1.4.0
+build==1.5.0
     # via pip-tools
-click==8.3.1
+click==8.4.1
     # via pip-tools
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   wheel
@@ -18,7 +18,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,19 +4,19 @@
 #
 #    make upgrade
 #
-coverage[toml]==7.13.4
+coverage[toml]==7.14.1
     # via pytest-cov
 iniconfig==2.3.0
     # via pytest
-packaging==26.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.2
+pytest==9.0.3
     # via pytest-cov
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in


### PR DESCRIPTION
This merge requests removes web_fragments as a dependency and upgrades all other dependencies.

See [This PR](https://github.com/openedx/XBlock/pull/917#issuecomment-4684554574) for context.